### PR TITLE
indicate support for Gnome 47

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,8 @@
   "description": "Fully customize your OSD ( On Screen Display ) pop ups like Volume , Brightness or Caffeine , Lock Keys etc. Move, orient, resize, numeric %, choose monitor, set hide-delay and style to match your theme and liking. You can also select any combination of components to display: icon, text-label, level-bar, numeric %. ",
   "shell-version": [
     "45",
-    "46"
+    "46",
+    "47"
   ],
   "url": "https://github.com/neuromorph/custom-osd",
   "gettext-domain": "custom-osd",


### PR DESCRIPTION
no broken changes are introduced in gnome 47
added the indication that this extension supports gnome 47
see [migration to gnome 47](https://gjs.guide/extensions/upgrading/gnome-shell-47.html)